### PR TITLE
restinparse v0.0.8 with batch operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 
 
+RestInParse 0.0.8
+===
+
+Rest In Parse now supports Batch operations 
+
+It works by creating a `stream` of data returned by  `ParseTable.batchUpdate()`, `ParseTable.batchCreate()` and `ParseTable.batchDelete()`
+
+You then call `RestInParse.batchExecutor(stream)` which will execute up to 20 operations for each http request
+
+
 RestInParse 0.0.7
 ===
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-RESTINPARSE_VERSION=0.0.7
+RESTINPARSE_VERSION=0.0.8
 RESTINPARSE_GROUP=com.github.jmfayard
 RESTINPARSE_ARTIFACT=restinparse
 SONATYPE_NEXUS_URL=http://repo.smfhq.com/artifactory/public

--- a/restinparse-core/src/main/java/com/github/jmfayard/ParseQuery.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/ParseQuery.java
@@ -253,6 +253,17 @@ public class ParseQuery<T extends ParseColumn> extends ParseTableInternal<T> {
             return new ParseQuery<>(className, params, _where, _includes, skip, limit, order, 1);
         }
 
+        public
+        @NotNull  Observable<ParseObject<T>> find() {
+            return build().find();
+        }
+
+        public
+        @NotNull  Observable<ParseObject<T>> findAll() {
+            return build().findAll();
+        }
+
+
 
         private Object datePtr(@NotNull Date date) {
             return objectOf("__type", "Date", "iso", dateFormat.format(date));

--- a/restinparse-core/src/main/java/com/github/jmfayard/ParseTable.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/ParseTable.java
@@ -1,6 +1,8 @@
 package com.github.jmfayard;
 
+import com.github.jmfayard.internal.ParseRestClientFactory;
 import com.github.jmfayard.internal.ParseTableInternal;
+import com.github.jmfayard.model.ParseBatchRequest;
 import com.github.jmfayard.model.ParseMapBuilder;
 import com.github.jmfayard.model.ParsePointer;
 import com.github.jmfayard.model.ParseMap;
@@ -45,19 +47,49 @@ public class ParseTable<T extends ParseColumn> extends ParseTableInternal<T> {
     }
 
     public Observable<ParseObject<T>> create(Map<T, Object> attributes) {
-        return super.createObject(rowMapOf(attributes));
+        return super.createObject(rawMap(attributes));
     }
 
     public Observable<ParseObject<T>> create(ParseMap attributes) {
-        return super.createObject(rowMapOf(attributes));
+        return super.createObject(rawMap(attributes));
     }
-
 
 
     @NotNull
     public Observable<ParseObject<T>> update(ParsePointer ptr, Map<T, Object> updates) {
         return this.update(ptr.objectId, updates);
     }
+
+    @NotNull
+    public ParseBatchRequest batchUpdate(String objectId, Map<T, Object> updates) {
+        return new ParseMapBuilder<T>(className, rawMap(updates)).batchUpdate(objectId);
+    }
+
+    @NotNull
+    public ParseBatchRequest batchUpdate(ParsePointer ptr, Map<T, Object> updates) {
+        return batchUpdate(ptr.objectId, updates);
+    }
+
+    @NotNull
+    public ParseBatchRequest batchDelete(String objectId) {
+        String path = String.format("%sclasses/%s/%s",
+                ParseRestClientFactory.basePath(), className, objectId);
+        return new ParseBatchRequest("DELETE", new HashMap<String, Object>(), path);
+    }
+
+    @NotNull
+    public ParseBatchRequest batchDelete(ParsePointer ptr) {
+        return batchDelete(ptr.objectId);
+    }
+
+    public ParseBatchRequest batchCreate(Map<T, Object> attributes) {
+        return new ParseMapBuilder<T>(className, rawMap(attributes)).batchCreate();
+    }
+
+    public ParseBatchRequest batchCreate(ParseMap attributes) {
+        return new ParseMapBuilder<T>(className, attributes.map()).batchCreate();
+    }
+
 
     public @NotNull Observable<ParseMap> delete(@NotNull String objectId) {
         return super.delete(objectId);
@@ -68,11 +100,7 @@ public class ParseTable<T extends ParseColumn> extends ParseTableInternal<T> {
     }
 
     public ParseMapBuilder<T> createMap() {
-        return new ParseMapBuilder();
-    }
-
-    public ParseMapBuilder<T> createMap(Map<T, Object> from) {
-        return new ParseMapBuilder(from);
+        return new ParseMapBuilder<T>(className);
     }
 
 

--- a/restinparse-core/src/main/java/com/github/jmfayard/RestInParse.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/RestInParse.java
@@ -106,7 +106,7 @@ public class RestInParse {
         return response.body();
     }
 
-    public static Observable<Object> batchExecutor(@NotNull Observable<ParseBatchRequest> stream) {
+    public static Observable<List<ParseBatchResponse>> batchExecutor(@NotNull Observable<ParseBatchRequest> stream) {
         return Settings.masterClient().batchExecutor(stream)
                 .map(RestInParse::assertSuccessfull);
 

--- a/restinparse-core/src/main/java/com/github/jmfayard/RestInParse.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/RestInParse.java
@@ -8,6 +8,7 @@ import okhttp3.RequestBody;
 import org.jetbrains.annotations.NotNull;
 import retrofit2.Response;
 import rx.Observable;
+import rx.Subscriber;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -38,7 +39,6 @@ public class RestInParse {
     private static ParseRestClient currentClient() {
         return Settings.currentClient();
     }
-
 
 
     @NotNull
@@ -98,9 +98,18 @@ public class RestInParse {
 
     private static <T> T assertSuccessfull(Response<T> response) {
         if (!response.isSuccessful()) {
-            throw new ParseError(response.code(), response.message());
+            ParseError error = new ParseError(response.code(), response.message());
+            System.err.println(error);
+            System.err.println(response.errorBody());
+            throw error;
         }
         return response.body();
+    }
+
+    public static Observable<Object> batchExecutor(@NotNull Observable<ParseBatchRequest> stream) {
+        return Settings.masterClient().batchExecutor(stream)
+                .map(RestInParse::assertSuccessfull);
+
     }
 
 

--- a/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestApi.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestApi.java
@@ -34,6 +34,9 @@ interface ParseRestApi {
     @GET("classes/{className}")
     Observable<Response<QueryResults>> query(@Path("className") String className, @QueryMap Map<String, String> queryOptions);
 
+    @POST("batch")
+    Observable<Response<Object>> batchRequests(@Body ParseBatch batch);
+
     /**
      * Cloud Code
      **/

--- a/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestApi.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestApi.java
@@ -35,7 +35,7 @@ interface ParseRestApi {
     Observable<Response<QueryResults>> query(@Path("className") String className, @QueryMap Map<String, String> queryOptions);
 
     @POST("batch")
-    Observable<Response<Object>> batchRequests(@Body ParseBatch batch);
+    Observable<Response<List<ParseBatchResponse>>> batchRequests(@Body ParseBatch batch);
 
     /**
      * Cloud Code

--- a/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClient.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClient.java
@@ -1,14 +1,12 @@
 package com.github.jmfayard.internal;
 
 
-import com.github.jmfayard.model.CloudResult;
-import com.github.jmfayard.model.ParseFile;
-import com.github.jmfayard.model.ParseResultSchemas;
-import com.github.jmfayard.model.ParseMap;
+import com.github.jmfayard.model.*;
 import okhttp3.RequestBody;
 import org.jetbrains.annotations.NotNull;
 import retrofit2.Response;
 import rx.Observable;
+import rx.Subscriber;
 
 import java.io.File;
 import java.util.List;
@@ -95,5 +93,11 @@ public class ParseRestClient {
 
     public Observable<File> downloadFile(@NotNull ParseFile parseFile, @NotNull File destination) {
         return null;
+    }
+
+    public Observable<Response<Object>> batchExecutor(@NotNull Observable<ParseBatchRequest> stream) {
+        return stream
+                .buffer(20)
+                .flatMap(list -> parseRestApi.batchRequests(new ParseBatch(list)));
     }
 }

--- a/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClient.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClient.java
@@ -95,7 +95,7 @@ public class ParseRestClient {
         return null;
     }
 
-    public Observable<Response<Object>> batchExecutor(@NotNull Observable<ParseBatchRequest> stream) {
+    public Observable<Response<List<ParseBatchResponse>>> batchExecutor(@NotNull Observable<ParseBatchRequest> stream) {
         return stream
                 .buffer(20)
                 .flatMap(list -> parseRestApi.batchRequests(new ParseBatch(list)));

--- a/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClientFactory.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClientFactory.java
@@ -7,10 +7,7 @@ import com.github.jmfayard.model.ParseError;
 import com.github.jmfayard.model.ParseMap;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import okhttp3.*;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.jetbrains.annotations.NotNull;
 import retrofit2.Retrofit;
@@ -29,6 +26,9 @@ public class ParseRestClientFactory {
     private static ParseRestApi loggedinClient;
     private static ParseRestApi masterClient;
 
+    public static String basePath() {
+        return HttpUrl.parse(PARSE_URL).encodedPath();
+    }
     public static void setHostedParseRestUrl(String url) {
         PARSE_URL = url;
     }

--- a/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClientFactory.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseRestClientFactory.java
@@ -1,6 +1,8 @@
 package com.github.jmfayard.internal;
 
 import com.github.jmfayard.ParseConfig;
+import com.github.jmfayard.model.ParseBatchRequest;
+import com.github.jmfayard.model.ParseBatchResponse;
 import com.github.jmfayard.model.ParseError;
 import com.github.jmfayard.model.ParseMap;
 import com.squareup.moshi.JsonAdapter;
@@ -136,6 +138,14 @@ public class ParseRestClientFactory {
 
     public static JsonAdapter<ParseMap> mapAdapter() {
         return moshi().adapter(ParseMap.class);
+    }
+
+    public static JsonAdapter<ParseBatchResponse> parseBatchResponseAdapter() {
+        return moshi().adapter(ParseBatchResponse.class);
+    }
+
+    public static JsonAdapter<ParseBatchRequest> parseBatchAdapter() {
+        return moshi().adapter(ParseBatchRequest.class);
     }
 
     public static JsonAdapter<ParseError> parseErrorAdapter() {

--- a/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseTableInternal.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/internal/ParseTableInternal.java
@@ -102,7 +102,7 @@ public class ParseTableInternal<T extends ParseColumn> {
     @NotNull
     protected Observable<ParseObject<T>> update(String objectId, Map<T, Object> updates) {
         ParseRestApi api = ParseRestClientFactory.masterClient();
-        Observable<Response<ParseMap>> response = api.updateObject(className, objectId, rowMapOf(updates));
+        Observable<Response<ParseMap>> response = api.updateObject(className, objectId, rawMap(updates));
         return response
                 .map(ParseTableInternal::assertSuccessfull)
                 .map(ParseObject::new);
@@ -110,7 +110,7 @@ public class ParseTableInternal<T extends ParseColumn> {
     }
 
     @NotNull
-    protected Map<String, Object> rowMapOf(Map<T, Object> updates) {
+    protected Map<String, Object> rawMap(Map<T, Object> updates) {
         Map<String, Object> map = new HashMap<>();
         for (Map.Entry entry : updates.entrySet()) {
             map.put(entry.getKey().toString(), entry.getValue());
@@ -119,7 +119,7 @@ public class ParseTableInternal<T extends ParseColumn> {
     }
 
     @NotNull
-    protected Map<String, Object> rowMapOf(ParseMap updates) {
+    protected Map<String, Object> rawMap(ParseMap updates) {
         Map<String, Object> map = new HashMap<>();
         map.putAll(updates.map());
         return map;

--- a/restinparse-core/src/main/java/com/github/jmfayard/model/QueryResults.java
+++ b/restinparse-core/src/main/java/com/github/jmfayard/model/QueryResults.java
@@ -17,5 +17,11 @@ public class QueryResults {
         }
     }
 
-
+    @Override
+    public String toString() {
+        return "QueryResults{" +
+                "results=" + results +
+                ", count=" + count +
+                '}';
+    }
 }

--- a/restinparse-core/src/test/kotlin/com/github/jmfayard/ApiTests.kt
+++ b/restinparse-core/src/test/kotlin/com/github/jmfayard/ApiTests.kt
@@ -60,9 +60,6 @@ class ApiTests : RxSpec() {
         val update = _User.table().createMap().set(_User.callsAccepted, true).build()
         ParseBatchRequest.update(user, update)
       }
-      rxScenario("Batch Stream", stream.take(1)) { a ->
-        a.debug("response")
-      }
       rxScenario("Batch Execute", RestInParse.batchExecutor(stream)) { a ->
         a.debug("response")
       }

--- a/restinparse-core/src/test/kotlin/com/github/jmfayard/ApiTests.kt
+++ b/restinparse-core/src/test/kotlin/com/github/jmfayard/ApiTests.kt
@@ -1,6 +1,7 @@
 package com.github.jmfayard
 
 import com.github.jmfayard.SelfieModel.*
+import com.github.jmfayard.model.ParseBatchRequest
 import com.github.jmfayard.model.ParseFile
 import com.github.jmfayard.model.ParseResultSchemas.ParseSchema
 import com.github.jmfayard.model.ParseUser
@@ -10,6 +11,7 @@ import io.kotlintest.matchers.be
 import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
 import rx.Observable
+import rx.subjects.Subject
 import java.io.File
 import java.util.*
 
@@ -45,8 +47,27 @@ class ApiTests : RxSpec() {
 
     RestInParse.startMasterSession()
 
-    allTests()
+    newTests()
+//    allTests()
 
+  }
+
+  fun newTests() {
+    feature("Batch operations") {
+      val users = _User.table().query().limit(10).find()
+
+      val stream = users.map { user ->
+        val update = _User.table().createMap().set(_User.callsAccepted, true).build()
+        ParseBatchRequest.update(user, update)
+      }
+      rxScenario("Batch Stream", stream.take(1)) { a ->
+        a.debug("response")
+      }
+      rxScenario("Batch Execute", RestInParse.batchExecutor(stream)) { a ->
+        a.debug("response")
+      }
+
+    }
   }
 
   fun allTests() {
@@ -57,6 +78,8 @@ class ApiTests : RxSpec() {
     val userFields = arrayOf("username", "objectId", "updatedAt", "createdAt")
     val basicFields = arrayOf("objectId", "updatedAt", "createdAt")
     val year2k = Date(1480418083000L)
+
+
 
 
     feature("Testing Parse Booleans") {


### PR DESCRIPTION
This code will update users 20 by 20 using Parse Batch Operations http://parseplatform.org/docs/rest/guide/#batch-operations

```kotlin

val updateStream = _User.table().query()
        .findAll()
        .map { user: ParseObject<_User> ->
          val updates = mapOf(_User.callsAccepted to true)
          _User.table().batchUpdate(user.id(), updates)
        }
RestInParse.batchExecutor(updateStream).subscribe()

```

